### PR TITLE
Fix sibling module import

### DIFF
--- a/src/b/proto/b/v1/b.proto
+++ b/src/b/proto/b/v1/b.proto
@@ -2,8 +2,9 @@ syntax = "proto3";
 
 package b.v1;
 
-import "buf.build/x/a/a/v1/a.proto";
+import "a/v1/a.proto";
 
 message BBB {
   string bbb = 1;
+  a.v1.AAA aaa = 2;
 }


### PR DESCRIPTION
Re: https://github.com/bufbuild/buf/issues/444

The `import` declaration included the fully-qualified module path (i.e. `buf.build/...`), which is not supported.

In a workspace, imports are resolved relative to each module's root, or the placement of the `buf.yaml` (similar to `protoc -I` paths, which is described [here](https://docs.buf.build/build/usage/#modules-and-workspaces)). Another example of importing files across sibling modules with a workspace is demonstrated in the [tour](https://docs.buf.build/tour/use-a-workspace#use-paymentapis-in-petapis).

In this case, the B module's `b/v1/b.proto` file can import the A module's `a/v1/a.proto` with:

```protobuf
import "a/v1/a.proto";
```

Also note that you do _not_ need to add the `buf.build/x/a` module to your `deps` to use it within a local workspace; the `buf.work.yaml` will suffice. Adding the module to your `deps` is only relevant when you're ready to push your modules to the BSR, which is described [here](https://docs.buf.build/reference/workspaces#pushing-modules).